### PR TITLE
2015 09 03 2 fixes

### DIFF
--- a/docs/release-note.md
+++ b/docs/release-note.md
@@ -12,13 +12,74 @@ Sometimes using callbacks will result in sprites show up as black, this is due t
 [Facebook: missing api function for js/lua binding](http://discuss.cocos2d-x.org/t/sdkbox-facebook-no-api-bug/23414)
 [Installer: fix COCOS_CONSOLE_ROOT invalid error](http://discuss.cocos2d-x.org/t/installation-error-for-sdkbox-iap/22898)
 
+##AdColony
+## Changelog
+1. Update AdColony iOS SDK to 2.5.3
+2. `register_PluginAdColonyLua_helper` -> `register_all_PluginAdColonyLua_helper`
+3. `#include "PluginAdColonyLuaHelper.hpp"` -> `#include "PluginAdColonyLuaHelper.h"`
+4. `#include "PluginAdColonyJSHelper.hpp"` -> `#include "PluginAdColonyJSHelper.h"`
+
+##AgeCheq
+## Changelog
+1. `register_PluginAgeCheqLua_helper` -> `register_all_PluginAgeCheqLua_helper`
+2. `#include "PluginAgeCheqLuaHelper.hpp"` -> `#include "PluginAgeCheqLuaHelper.h"`
+3. `#include "PluginAgeCheqJSHelper.hpp"` -> `#include "PluginAgeCheqJSHelper.h"`
+
+##Chartboost
+## Changelog
+1. `register_PluginChartboostJS_helper` -> `register_all_PluginChartboostJS_helper`
+2. `register_PluginChartboostLua_helper` -> `register_all_PluginChartboostLua_helper`
+3. Update Chartboost iOS SDK to 5.5.3
+4. Update Chartboost Android SDK to 5.5.3
+5. `#include "PluginChartboostLuaHelper.hpp"` -> `#include "PluginChartboostLuaHelper.h"`
+
+##Facebook
+## Changelog
+1. `register_PluginFacebookJS_helper` -> `register_all_PluginFacebookJS_helper`
+2. `register_PluginFacebookLua_helper` -> `register_all_PluginFacebookLua_helper`
+3. Update Facebook iOS SDK to 4.5.1
+4. Update Facebook Android SDK to 4.5.1
+5. `#include "PluginFacebookLuaHelper.hpp"` -> `#include "PluginFacebookLuaHelper.h"`
+
+##Flurry Analytics
+## Changelog
+1. `register_PluginFlurryAnalyticsJS_helper` -> `register_all_PluginFlurryAnalyticsJS_helper`
+2. `register_PluginFlurryAnalyticsLua_helper` -> `register_all_PluginFlurryAnalyticsLua_helper`
+3. Update Flurry iOS SDK to 6.7.0
+4. Update Flurry Android SDK to 5.6.0
+5. `#include "PluginFlurryAnalyticsLuaHelper.hpp"` -> `#include "PluginFlurryAnalyticsLuaHelper.h"`
+
+##Google Analytics
+## Changelog
+1. `#include "PluginGoogleAnalyticsLuaHelper.hpp"` -> `#include "PluginGoogleAnalyticsLuaHelper.h"`
+
+##IAP
+## Changelog
+1. `register_PluginIAPLua_helper` -> `register_all_PluginIAPLua_helper`
+2. `#include "PluginIAPLuaHelper.hpp"` -> `#include "PluginIAPLuaHelper.h"`
+3. `#include "PluginIAPJSHelper.hpp"` -> `#include "PluginIAPJSHelper.h"`
+
+##Tune
+1. `register_PluginTuneJS_helper` -> `register_all_PluginTuneJS_helper`
+2. `register_PluginTuneLua_helper` -> `register_all_PluginTuneLua_helper`
+3. Update MobileAppTracker Android SDK to 3.10.1
+4. `#include "PluginTuneLuaHelper.hpp"` -> `#include "PluginTuneLuaHelper.h"`
+
+##Vungle
+## Changelog
+1. `register_PluginVungleJS_helper` -> `register_all_PluginVungleJS_helper`
+2. `register_PluginVungleLua_helper` -> `register_all_PluginVungleLua_helper`
+3. `#include "PluginVungleLuaHelper.hpp"` -> `#include "PluginVungleLuaHelper.h"`
+
+
+
 1.2.2 Release Notes
 ====
 ##Highlight
 * Installer will automatically modify `Cocos2dxActivity.java` for you
 * Facebook Plugin supports `getFriends()` function
 * IAP supports `onRestoreComplete()` callback
-* IAP will auto consume items if 
+* IAP will auto consume items if
 
 ##Bugfix
 

--- a/src/adcolony/readme.md
+++ b/src/adcolony/readme.md
@@ -10,14 +10,6 @@ Open a terminal and use the following command to install the SDKBOX AdColony plu
 $ sdkbox import adcolony
 ```
 
-## Changelog
-
-version-x.y.z:
-1. Update AdColony iOS SDK to 2.5.3
-2. `register_PluginAdColonyLua_helper` -> `register_all_PluginAdColonyLua_helper`
-3. `#include "PluginAdColonyLuaHelper.hpp"` -> `#include "PluginAdColonyLuaHelper.h"`
-4. `#include "PluginAdColonyJSHelper.hpp"` -> `#include "PluginAdColonyJSHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `res/sdkbox_config.json`, that you have to modify it before you can use it for your own app
 
@@ -56,4 +48,3 @@ Here is an example of the AdColony configuration, you need to replace `<app id>`
 
 <<[extra-step.md]
 <<[proguard.md]
-

--- a/src/agecheq/readme.md
+++ b/src/agecheq/readme.md
@@ -10,13 +10,6 @@ Open a terminal and use the following command to install the SDKBOX AgeCheq plug
 $ sdkbox import agecheq
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginAgeCheqLua_helper` -> `register_all_PluginAgeCheqLua_helper`
-2. `#include "PluginAgeCheqLuaHelper.hpp"` -> `#include "PluginAgeCheqLuaHelper.h"`
-3. `#include "PluginAgeCheqJSHelper.hpp"` -> `#include "PluginAgeCheqJSHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `res/sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/chartboost/readme.md
+++ b/src/chartboost/readme.md
@@ -10,15 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Chartboost p
 $ sdkbox import chartboost
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginChartboostJS_helper` -> `register_all_PluginChartboostJS_helper`
-2. `register_PluginChartboostLua_helper` -> `register_all_PluginChartboostLua_helper`
-3. Update Chartboost iOS SDK to 5.5.3
-4. Update Chartboost Android SDK to 5.5.3
-5. `#include "PluginChartboostLuaHelper.hpp"` -> `#include "PluginChartboostLuaHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/facebook/readme.md
+++ b/src/facebook/readme.md
@@ -10,14 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Facebook plu
 $ sdkbox import facebook
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginFacebookJS_helper` -> `register_all_PluginFacebookJS_helper`
-2. `register_PluginFacebookLua_helper` -> `register_all_PluginFacebookLua_helper`
-3. Update Facebook iOS SDK to 4.5.1
-4. Update Facebook Android SDK to 4.5.1
-5. `#include "PluginFacebookLuaHelper.hpp"` -> `#include "PluginFacebookLuaHelper.h"`
 ##Extra steps
 
 The following step assuming you already registered as a Facebook Developer

--- a/src/facebook/readme.md
+++ b/src/facebook/readme.md
@@ -4,6 +4,9 @@ Include Base: /Users/jtsm/Chukong-Inc/pr/en/src/facebook/v3-cpp
 
 #Facebook
 
+##Prerequisites
+* __For Android, Facebook requires a minimum version of 4.0.3. This version is newer than what the other SDKBOX plugins require.__
+
 ##Integration
 Open a terminal and use the following command to install the SDKBOX Facebook plugin. Make sure you setup SDKBOX installer correctly.
 ```bash

--- a/src/facebook/v3-cpp/usage.md
+++ b/src/facebook/v3-cpp/usage.md
@@ -50,7 +50,7 @@ There are two types of sharing functionality.
 share a link:
 ```cpp
 sdkbox::FBShareInfo info;
-info.type  = FB_LINK;
+info.type  = sdkbox::FB_LINK;
 info.link  = "http://www.cocos2d-x.org";
 info.title = "cocos2d-x";
 info.text  = "Best Game Engine";
@@ -60,7 +60,7 @@ sdkbox::PluginFacebook::share(info);
 share a photo:
 ```cpp
 sdkbox::FBShareInfo info;
-info.type  = FB_PHOTO;
+info.type  = sdkbox::FB_PHOTO;
 info.title = "My Photo";
 info.image = __path to image__;
 sdkbox::PluginFacebook::share(info);
@@ -70,7 +70,7 @@ sdkbox::PluginFacebook::share(info);
 present a share dialog:
 ```cpp
 sdkbox::FBShareInfo info;
-info.type  = FB_LINK;
+info.type  = sdkbox::FB_LINK;
 info.link  = "http://www.cocos2d-x.org";
 info.title = "cocos2d-x";
 info.text  = "Best Game Engine";
@@ -81,7 +81,7 @@ sdkbox::PluginFacebook::dialog(info);
 share a photo with comments:
 ```cpp
 sdkbox::FBShareInfo info;
-info.type  = FB_PHOTO;
+info.type  = sdkbox::FB_PHOTO;
 info.title = "My Photo";
 info.image = __path to image__;
 sdkbox::PluginFacebook::dialog(info);

--- a/src/flurryanalytics/readme.md
+++ b/src/flurryanalytics/readme.md
@@ -10,15 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Flurry Analy
 $ sdkbox import flurryanalytics
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginFlurryAnalyticsJS_helper` -> `register_all_PluginFlurryAnalyticsJS_helper`
-2. `register_PluginFlurryAnalyticsLua_helper` -> `register_all_PluginFlurryAnalyticsLua_helper`
-3. Update Flurry iOS SDK to 6.7.0
-4. Update Flurry Android SDK to 5.6.0
-5. `#include "PluginFlurryAnalyticsLuaHelper.hpp"` -> `#include "PluginFlurryAnalyticsLuaHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/googleanalytics/readme.md
+++ b/src/googleanalytics/readme.md
@@ -10,11 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Google Analy
 $ sdkbox import googleanalytics
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `#include "PluginGoogleAnalyticsLuaHelper.hpp"` -> `#include "PluginGoogleAnalyticsLuaHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `res/sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/iap/readme.md
+++ b/src/iap/readme.md
@@ -10,13 +10,6 @@ Open a terminal and use the following command to install the SDKBOX IAP plugin. 
 $ sdkbox import iap
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginIAPLua_helper` -> `register_all_PluginIAPLua_helper`
-2. `#include "PluginIAPLuaHelper.hpp"` -> `#include "PluginIAPLuaHelper.h"`
-3. `#include "PluginIAPJSHelper.hpp"` -> `#include "PluginIAPJSHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/tune/readme.md
+++ b/src/tune/readme.md
@@ -10,14 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Tune plugin.
 $ sdkbox import tune
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginTuneJS_helper` -> `register_all_PluginTuneJS_helper`
-2. `register_PluginTuneLua_helper` -> `register_all_PluginTuneLua_helper`
-3. Update MobileAppTracker Android SDK to 3.10.1
-4. `#include "PluginTuneLuaHelper.hpp"` -> `#include "PluginTuneLuaHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `sdkbox_config.json`, that you have to modify it before you can use it for your own app
 

--- a/src/vungle/readme.md
+++ b/src/vungle/readme.md
@@ -10,13 +10,6 @@ Open a terminal and use the following command to install the SDKBOX Vungle plugi
 $ sdkbox import vungle
 ```
 
-## Changelog
-
-version-x.y.z:
-1. `register_PluginVungleJS_helper` -> `register_all_PluginVungleJS_helper`
-2. `register_PluginVungleLua_helper` -> `register_all_PluginVungleLua_helper`
-3. `#include "PluginVungleLuaHelper.hpp"` -> `#include "PluginVungleLuaHelper.h"`
-
 ## Configuration
 SDKBOX Installer will automatically inject a sample configuration to your `sdkbox_config.json`, that you have to modify it before you can use it for your own app
 


### PR DESCRIPTION
moved Change Log from each plugin doc to release_notes.md

added namespace to a few Facebook items for clarity.

added a bold prerequisite that Facebook requires a newer version of Android OS than our other plugins.