### PR TITLE
Fix installation script curl issue.

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -324,7 +324,7 @@ def check_installer(sdkbox_dir):
     return os.path.isfile(sdkbox_file)
 
 def download_installer(path, info):
-    response = Utils.curl(info['url'], None, 1024, Utils.progress_bar)
+    response = Utils.curl(info['url'], None, None, Utils.progress_bar)
     sha1 = Utils.calculate_sha1(response)
     if sha1 != info['sha1']:
         raise RuntimeError('ERROR! SHA1 of update does not match\nFound  : {0}\nNeeded : {1}'.format(sha1, info['sha1']))
@@ -341,7 +341,7 @@ def download_installer(path, info):
 
 def get_installer_url():
     url = 'http://download.sdkbox.com/installer/v1/manifest.json'
-    data = Utils.curl(url, None, 1024, None)
+    data = Utils.curl(url, None, None, None)
     if not data or 0 == len(data):
         raise Exception('ERROR! load manifest fail')
     manifest = json.loads(data)

--- a/install/install.py
+++ b/install/install.py
@@ -42,8 +42,6 @@ class Utils:
                         break
                     size += len(chunk)
                     if None != callback:
-                        if total_size == 0:
-                            total_size = size
                         callback(size, total_size)
                     data += chunk
         except Exception as e:


### PR DESCRIPTION
It fails on windows and blocks cocos creator sdkbox ui with the exception:
ERROR! url:http://download.sdkbox.com/installer/v1/manifest.json
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 403, in <module>
  File "<string>", line 386, in main
  File "<string>", line 346, in get_installer_url
Exception: ERROR! load manifest fail